### PR TITLE
Update Documentation to Include `session_date` in Recording Session Creation

### DIFF
--- a/api-reference/scribing-endpoints/recording-sessions/create-recording-session.mdx
+++ b/api-reference/scribing-endpoints/recording-sessions/create-recording-session.mdx
@@ -4,17 +4,21 @@ openapi: 'POST /recording-sessions/create'
 ---
 
 ## Overview
-This endpoint creates a new recording session to be used for scribing. The generated <code>public_id</code> will be required for uploading your audio file in subsequent steps.
+This endpoint creates a new recording session to be used for scribing.  
+The generated `public_id` will be required for uploading your audio file in subsequent steps.
 
 ## Request Body
-- **`patient_name`** (string) - Name of the patient. 
- > **Note:** `patient_name` must match the patient's name in the uploaded audio (if any) to ensure the record is generated only for the scheduled patient. PupPilot uses this information to avoid inclusion of unrelated pet discussions.
-- **`description`** (string) - Short description of the session.
+- **`patient_name`** (string) - Name of the patient.  
+  > **Note:** `patient_name` must match the patient's name in the uploaded audio (if any) to ensure the record is generated only for the scheduled patient. PupPilot uses this information to avoid inclusion of unrelated pet discussions.  
+- **`description`** (string, optional) - Short description of the session.  
+- **`session_date`** (date, required) - The date of the session (**format: `YYYY-MM-DD`**).  
 
 ## Example Request
 ```json
 {
   "patient_name": "Max",
-  "description": "Wellness appointment"
+  "description": "Wellness appointment",
+  "session_date": "2025-03-18"
 }
+```
 


### PR DESCRIPTION
## **📢 Summary**  
This PR updates the API documentation to reflect the addition of the `session_date` field in the **Create Recording Session** endpoint. The update ensures that API consumers understand the required format and purpose of this field.

## **🔹 Changes Introduced**  
- **Added `session_date` field** in the request body section.  
- **Specified the required format (`YYYY-MM-DD`)** for consistency.  
- **Updated the example request** to include `session_date`.  

## **📌 Why This Change?**  
- `session_date` is now required for proper session organization and grouping in the app.  
- Ensures that API clients send the correct format to prevent errors.  